### PR TITLE
Fix bug with set_next

### DIFF
--- a/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
@@ -242,12 +242,15 @@ end
 
 local random_selection_mode = false
 local function select_map()
+	local idx
+
 	-- If next_idx exists, return the same
 	if ctf_map.next_idx then
-		return ctf_map.next_idx
+		idx = ctf_map.next_idx
+		ctf_map.next_idx = nil
+		return idx
 	end
 
-	local idx
 	if random_selection_mode then
 		-- Get the real idx stored in table shuffled_order at index [shuffled_idx]
 		idx = shuffled_order[shuffled_idx]


### PR DESCRIPTION
Before this fix, when a next map was set via `set_next` or similiar methods, this map was selected as next for all eternity, so that the actual map selection wasn't run anymore.